### PR TITLE
Chromium support v2 (#97)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: required
-dist: trusty
+dist: xenial
 addons:
   firefox: latest
   chrome: stable
+services: xvfb
 language: python
 python:
 - '3.6'
@@ -11,11 +12,8 @@ before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
 - sudo apt-get update -y
-- sudo apt install opera-stable
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile
-  --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+- sudo apt-get -y --no-install-recommends install opera-stable
+- opera --version
 
 install:
 - pip install pipenv

--- a/tests/test_chromium_driver.py
+++ b/tests/test_chromium_driver.py
@@ -1,0 +1,62 @@
+import os
+
+import pytest
+from selenium import webdriver
+
+from webdriver_manager.chrome import ChromeDriverManager
+from webdriver_manager.utils import ChromeType
+
+
+def test_chromium_manager_with_specific_version():
+    bin_path = ChromeDriverManager("2.27", chrome_type=ChromeType.CHROMIUM).install()
+    assert os.path.exists(bin_path)
+
+
+def test_driver_can_be_saved_to_custom_path():
+    custom_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "custom")
+
+    path = ChromeDriverManager(version="2.27", path=custom_path,
+                               chrome_type=ChromeType.CHROMIUM).install()
+    assert os.path.exists(path)
+    assert custom_path in path
+
+
+@pytest.mark.parametrize('path', [".", None])
+def test_chromium_manager_with_latest_version(path):
+    bin_path = ChromeDriverManager(path=path,
+                                   chrome_type=ChromeType.CHROMIUM).install()
+    assert os.path.exists(bin_path)
+
+
+def test_chromium_manager_with_wrong_version():
+    with pytest.raises(ValueError) as ex:
+        ChromeDriverManager("0.2", chrome_type=ChromeType.CHROMIUM).install()
+    assert "There is no such driver by url" in ex.value.args[0]
+
+
+def test_chromium_manager_with_selenium():
+    driver_path = ChromeDriverManager(
+        chrome_type=ChromeType.CHROMIUM).install()
+    driver = webdriver.Chrome(driver_path)
+    driver.get("http://automation-remarks.com")
+    driver.close()
+
+
+@pytest.mark.parametrize('path', [".", None])
+def test_chromium_manager_cached_driver_with_selenium(path):
+    ChromeDriverManager(path=path, chrome_type=ChromeType.CHROMIUM).install()
+    webdriver.Chrome(ChromeDriverManager(
+        path=path, chrome_type=ChromeType.CHROMIUM).install())
+
+
+@pytest.mark.parametrize('path', [".", None])
+def test_chromium_manager_with_win64_os(path):
+    ChromeDriverManager(os_type="win64", path=path,
+                        chrome_type=ChromeType.CHROMIUM).install()
+
+
+@pytest.mark.parametrize('os_type', ['win32', 'win64'])
+def test_can_get_chromium_for_win(os_type):
+    path = ChromeDriverManager(os_type=os_type,
+                               chrome_type=ChromeType.CHROMIUM).install()
+    assert os.path.exists(path)

--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -3,6 +3,7 @@ import os
 from webdriver_manager import utils
 from webdriver_manager.driver import ChromeDriver
 from webdriver_manager.manager import DriverManager
+from webdriver_manager.utils import ChromeType
 
 
 class ChromeDriverManager(DriverManager):
@@ -11,14 +12,16 @@ class ChromeDriverManager(DriverManager):
                  path=None,
                  name="chromedriver",
                  url="http://chromedriver.storage.googleapis.com",
-                 latest_release_url="http://chromedriver.storage.googleapis.com/LATEST_RELEASE"):
+                 latest_release_url="http://chromedriver.storage.googleapis.com/LATEST_RELEASE",
+                 chrome_type=ChromeType.GOOGLE):
         super(ChromeDriverManager, self).__init__(path)
 
         self.driver = ChromeDriver(name=name,
                                    version=version,
                                    os_type=os_type,
                                    url=url,
-                                   latest_release_url=latest_release_url)
+                                   latest_release_url=latest_release_url,
+                                   chrome_type=chrome_type)
 
     def install(self):
         driver_path = self.download_driver(self.driver)

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -4,7 +4,8 @@ from xml.etree import ElementTree
 
 import requests
 
-from webdriver_manager.utils import validate_response, console, chrome_version
+from webdriver_manager.utils import validate_response, console, \
+    chrome_version, ChromeType
 
 
 class Driver(object):
@@ -41,8 +42,10 @@ class Driver(object):
 
 
 class ChromeDriver(Driver):
-    def __init__(self, name, version, os_type, url, latest_release_url):
+    def __init__(self, name, version, os_type, url, latest_release_url,
+                 chrome_type=ChromeType.GOOGLE):
         super(ChromeDriver, self).__init__(name, version, os_type, url, latest_release_url)
+        self.chrome_type = chrome_type
 
     def get_os_type(self):
         if "win" in super().get_os_type():
@@ -51,7 +54,7 @@ class ChromeDriver(Driver):
 
     def get_latest_release_version(self):
         resp = requests.get(
-            self._latest_release_url + '_' + chrome_version())
+            self._latest_release_url + '_' + chrome_version(self.chrome_type))
         validate_response(resp)
         return resp.text.rstrip()
 

--- a/webdriver_manager/utils.py
+++ b/webdriver_manager/utils.py
@@ -14,6 +14,11 @@ class OSType(object):
     WIN = "win"
 
 
+class ChromeType(object):
+    GOOGLE = 'google-chrome'
+    CHROMIUM = 'chromium'
+
+
 def os_name():
     pl = sys.platform
     if pl == "linux" or pl == "linux2":
@@ -81,15 +86,22 @@ def console(text, bold=False):
     print(crayons.yellow(text, bold=bold))
 
 
-def chrome_version():
+def chrome_version(browser_type=ChromeType.GOOGLE):
     pattern = r'\d+\.\d+\.\d+'
     cmd_mapping = {
-        OSType.LINUX: 'google-chrome --version',
-        OSType.MAC: r'/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
-        OSType.WIN: r'reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version'
+        ChromeType.GOOGLE: {
+            OSType.LINUX: 'google-chrome --version',
+            OSType.MAC: r'/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
+            OSType.WIN: r'reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version'
+        },
+        ChromeType.CHROMIUM: {
+            OSType.LINUX: 'chromium --version',
+            OSType.MAC: r'/Applications/Chromium.app/Contents/MacOS/Chromium --version',
+            OSType.WIN: r'reg query "HKEY_CURRENT_USER\Software\Chromium\BLBeacon" /v version'
+        }
     }
 
-    cmd = cmd_mapping[os_name()]
+    cmd = cmd_mapping[browser_type][os_name()]
     stdout = os.popen(cmd).read()
     version = re.search(pattern, stdout)
     if not version:


### PR DESCRIPTION
* Add Chromium browser support (Resolves #93)

* Extend Chromium from Chrome DriverManage.

* return empty line into the EOF

* dist: xenial

* add `services:xvfb` instead of scripting setup in before_install

* Add missed `sudo` to install opera-stable

* Parametrize ChromeDriverManager with chrome_type: google-chrome, chromium

* Fix chromium tests, use different chromedriver versions to not to hit cached versions of chrome tests

* PEP8: driver.py and test_chromium_driver.py, others contains long strings and couldn't be fixed normally